### PR TITLE
Add functionality for using items on one another

### DIFF
--- a/interactions.py
+++ b/interactions.py
@@ -179,8 +179,11 @@ def terminalUse(terminal, player, item):
 
 def smash(player, item):
     if item.name == "capacitor":
+        item.name = "smashed capacitor"
+        item.description = "The remains of what could have been a very useful and important component, reduced to a tiny pile of crushed ceramic, metal and plastic."
         print(f"For whatever reason, you decide to crush the capacitor beyond recognition. Are you happy now?")
-        player.inventory.append()
+        
     elif item.isName("ladder"):
+        item.name = "smashed ladder"
+        item.description = "The rungs that remain are too far apart to be remotely usable. Not much of a ladder anymore, really."
         print(f"You decide you've had enough of your ladder. After hammering away at the poor vertical convyance device for a few minutes, you come to your senses and cut it out.")
-    player.inventory.remove(item)

--- a/interactions.py
+++ b/interactions.py
@@ -178,9 +178,8 @@ def terminalUse(terminal, player, item):
         terminal.actions["use"] = terminal.onUse
 
 def smash(player, item):
-    if item.name == "capacitor":
+    if item.isName("capacitor"):
         item.name = "smashed capacitor"
-        item.description = "The remains of what could have been a very useful and important component, reduced to a tiny pile of crushed ceramic, metal and plastic."
         print(f"For whatever reason, you decide to crush the capacitor beyond recognition. Are you happy now?")
         
     elif item.isName("ladder"):

--- a/interactions.py
+++ b/interactions.py
@@ -176,3 +176,11 @@ def terminalUse(terminal, player, item):
         terminal.name = "terminal (broken)"
         terminal.desc = "It's damaged beyond repair. Maybe you shouldn't have done that..."
         terminal.actions["use"] = terminal.onUse
+
+def smash(player, item):
+    if item.name == "capacitor":
+        print(f"For whatever reason, you decide to crush the capacitor beyond recognition. Are you happy now?")
+        player.inventory.append()
+    elif item.isName("ladder"):
+        print(f"You decide you've had enough of your ladder. After hammering away at the poor vertical convyance device for a few minutes, you come to your senses and cut it out.")
+    player.inventory.remove(item)

--- a/main.py
+++ b/main.py
@@ -411,4 +411,5 @@ def main():
 
 
 if __name__ == "__main__":
+
     main()

--- a/main.py
+++ b/main.py
@@ -301,6 +301,7 @@ def main():
         "get/grab/pickup",
         "l(ook)",
         "use <inventory item> on <object in room>",
+        "use <inventory item> on <inventory item>"
         "use <object in room>",
     ]
 
@@ -369,12 +370,15 @@ def main():
         elif verb.lower() == "use":
             matches = re.match(r"use\s+(.+)\s+on\s+(.+)", userText)
             if matches:
-                usedItem = you.getItem(matches[1].lower())
+                usedItem = you.getItem(matches[1].lower()) #checks if first term specified exists within player
                 interactable = you.currentLocation.getInteractable(matches[2].lower())
+                secondItem = you.getItem(matches[2].lower())
                 if not usedItem:
                     prRed(f"    You do not have a {matches[1]} in your inventory.")
                 elif not interactable:
                     prRed(f"     There is no {matches[2]} nearby.")
+                elif secondItem and usedItem.name == "wrench":
+                    interactions.smash(you, {matches[2]})
                 else:
                     if not interactable.doInteraction(you, "use", usedItem):
                         prRed(

--- a/main.py
+++ b/main.py
@@ -378,7 +378,7 @@ def main():
                 elif not interactable:
                     prRed(f"     There is no {matches[2]} nearby.")
                 elif secondItem and usedItem.name == "wrench":
-                    interactions.smash(you, {matches[2]})
+                    interactions.smash(you, secondItem)
                 else:
                     if not interactable.doInteraction(you, "use", usedItem):
                         prRed(

--- a/world.json
+++ b/world.json
@@ -91,12 +91,6 @@
       "hidden": true,
       "gettable": true
     },
-    "smashed capacitor": {
-      "aliases": [],
-      "description": "The remains of what could have been a very useful and important component, reduced to a tiny pile of crushed ceramic, metal and plastic.",
-      "hidden": true,
-      "gettable": true
-    },
     "radio": {
       "aliases": ["radio"],
       "description": "The radio is broken",
@@ -106,12 +100,6 @@
     "ladder": {
       "aliases": [],
       "description": "A vertical conveyance device",
-      "hidden": false,
-      "gettable": true
-    },
-    "smashed ladder": {
-      "aliases": [],
-      "description": "The rungs that remain are too far apart to be remotely usable. Not much of a ladder anymore, really.",
       "hidden": false,
       "gettable": true
     },

--- a/world.json
+++ b/world.json
@@ -91,6 +91,12 @@
       "hidden": true,
       "gettable": true
     },
+    "smashed capacitor": {
+      "aliases": [],
+      "description": "The remains of what could have been a very useful and important component, reduced to a tiny pile of crushed ceramic, metal and plastic.",
+      "hidden": true,
+      "gettable": true
+    },
     "radio": {
       "aliases": ["radio"],
       "description": "The radio is broken",
@@ -100,6 +106,12 @@
     "ladder": {
       "aliases": [],
       "description": "A vertical conveyance device",
+      "hidden": false,
+      "gettable": true
+    },
+    "smashed ladder": {
+      "aliases": [],
+      "description": "The rungs that remain are too far apart to be remotely usable. Not much of a ladder anymore, really.",
       "hidden": false,
       "gettable": true
     },


### PR DESCRIPTION
Implemented an option for the player to "use" two items within their inventory on one another. In this case, the only functionality is to use the wrench on the capacitor or ladder to "smash" them. These items are now unusable if smashed, soft-locking the player.